### PR TITLE
fix: issue with PositionalEncoder arange not properly being created on device of Tensor

### DIFF
--- a/rff/functional.py
+++ b/rff/functional.py
@@ -70,7 +70,7 @@ def positional_encoding(
 
     See :class:`~rff.layers.PositionalEncoding` for more details.
     """
-    j = torch.arange(m)
+    j = torch.arange(m, device=v.device)
     coeffs = 2 * np.pi * sigma ** (j / m)
     vp = coeffs * torch.unsqueeze(v, -1)
     vp_cat = torch.cat((torch.cos(vp), torch.sin(vp)), dim=-1)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -17,4 +17,4 @@ class DataloaderTest(unittest.TestCase):
         np.testing.assert_equal(coords, expected_coords)
 
     def test_to_dataset(self):
-        dataset = rff.dataloader.to_dataset('images/cat.jpg')
+        _ = rff.dataloader.to_dataset('images/cat.jpg')

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -1,4 +1,3 @@
-from types import new_class
 import numpy as np
 import torch
 import unittest

--- a/test/test_layers.py
+++ b/test/test_layers.py
@@ -1,43 +1,56 @@
+"""
+Test layers, the point to to make sure they can be created and that the output matches
+the corresponding functional calls. Other testing will be performed in the functional
+test.
+"""
+
 import numpy as np
-import unittest
 import rff
+import pytest
+import torch
 
 
-class LayerTest(unittest.TestCase):
-    """
-    Test layers, the point to to make sure they can be created and that the output matches
-    the corresponding functional calls. Other testing will be performed in the functional
-    test.
-    """
+def check_cuda(device):
+    if device == 'cuda' and not torch.cuda.is_available():
+        pytest.skip('Cuda is not available')
 
-    def test_gaussian_encoding(self):
-        b = rff.functional.sample_b(1.0, (256, 2))
-        layer = rff.layers.GaussianEncoding(b=b)
-        v = rff.dataloader.rectangular_coordinates((256, 256))
-        gamma_v = layer(v)
-        gamma_v_expected = rff.functional.gaussian_encoding(v, b)
-        np.testing.assert_almost_equal(
-            gamma_v.numpy(),
-            gamma_v_expected.numpy(),
-            decimal=5)
 
-    def test_basic_encoding(self):
-        layer = rff.layers.BasicEncoding()
-        v = rff.dataloader.rectangular_coordinates((256, 256))
-        gamma_v = layer(v)
-        gamma_v_expected = rff.functional.basic_encoding(v)
-        np.testing.assert_almost_equal(
-            gamma_v.numpy(),
-            gamma_v_expected.numpy(),
-            decimal=5)
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_gaussian_encoding(device):
+    check_cuda(device)
+    b = rff.functional.sample_b(1.0, (256, 2)).to(device)
+    layer = rff.layers.GaussianEncoding(b=b).to(device)
+    v = rff.dataloader.rectangular_coordinates((256, 256)).to(device)
+    gamma_v = layer(v)
+    gamma_v_expected = rff.functional.gaussian_encoding(v, b)
+    np.testing.assert_almost_equal(
+        gamma_v.cpu().numpy(),
+        gamma_v_expected.cpu().numpy(),
+        decimal=5)
 
-    def test_positional_encoding(self):
-        layer = rff.layers.PositionalEncoding(sigma=1.0, m=10)
-        v = rff.dataloader.rectangular_coordinates((256, 256))
-        gamma_v = layer(v)
-        gamma_v_expected = rff.functional.positional_encoding(
-            v, sigma=1.0, m=10)
-        np.testing.assert_almost_equal(
-            gamma_v.numpy(),
-            gamma_v_expected.numpy(),
-            decimal=5)
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_basic_encoding(device):
+    check_cuda(device)
+    layer = rff.layers.BasicEncoding().to(device)
+    v = rff.dataloader.rectangular_coordinates((256, 256)).to(device)
+    gamma_v = layer(v)
+    gamma_v_expected = rff.functional.basic_encoding(v)
+    np.testing.assert_almost_equal(
+        gamma_v.cpu().numpy(),
+        gamma_v_expected.cpu().numpy(),
+        decimal=5)
+
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_positional_encoding(device):
+    check_cuda(device)
+    layer = rff.layers.PositionalEncoding(sigma=1.0, m=10).to(device)
+    v = rff.dataloader.rectangular_coordinates((256, 256)).to(device)
+    gamma_v = layer(v)
+    gamma_v_expected = rff.functional.positional_encoding(
+        v, sigma=1.0, m=10)
+    np.testing.assert_almost_equal(
+        gamma_v.cpu().numpy(),
+        gamma_v_expected.cpu().numpy(),
+        decimal=5)


### PR DESCRIPTION
The `torch.arange(m)` was being created on CPU, regardless of the input tensor. 

I added some unit tests to check for this issue, so all layers should be covered for the `'cpu'` and `'cuda'` cases.

Fixes #2 