### PR TITLE
doc: fix issue with positional encoding doc not rendering equation

### DIFF
--- a/rff/functional.py
+++ b/rff/functional.py
@@ -57,7 +57,7 @@ def positional_encoding(
         v: Tensor,
         sigma: float,
         m: int) -> Tensor:
-    r"""`\gamma(\mathbf{v}) = (\dots, \cos{2 \pi \sigma^{(j/m)} \mathbf{v}} , \sin{2 \pi \sigma^{(j/m)} \mathbf{v}}, \dots)`
+    r"""Computes :math:`\gamma(\mathbf{v}) = (\dots, \cos{2 \pi \sigma^{(j/m)} \mathbf{v}} , \sin{2 \pi \sigma^{(j/m)} \mathbf{v}}, \dots)`
         where :math:`j \in \{0, \dots, m-1\}`
 
     Args:


### PR DESCRIPTION
The positional encoding docstring was missing :math: as required by sphinx for rendering in the doc. I have added it in this PR.