### PR TITLE
chore: cut 1.0.1, add test, fix deprecation warning on meshgrid

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2021-2022, Joshua Mark Coley Long'
 author = 'Joshua Mark Coley Long'
 
 # The full version, including alpha/beta/rc tags
-release = '1.0.0'
+release = '1.0.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/rff/__init__.py
+++ b/rff/__init__.py
@@ -2,4 +2,4 @@ import rff.functional
 import rff.layers
 import rff.dataloader
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/rff/dataloader.py
+++ b/rff/dataloader.py
@@ -16,7 +16,7 @@ def rectangular_coordinates(size: tuple) -> Tensor:
     """
     def linspace_func(nx): return torch.linspace(0.0, 1.0, nx)
     linspaces = map(linspace_func, size)
-    coordinates = torch.meshgrid(*linspaces)
+    coordinates = torch.meshgrid(*linspaces, indexing='ij')
     return torch.stack(coordinates, dim=-1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 setup(name='random-fourier-features-pytorch',
-      version='1.0.0',
+      version='1.0.1',
       description='Random Fourier Features for PyTorch',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/test/test_layers.py
+++ b/test/test_layers.py
@@ -30,6 +30,15 @@ def test_gaussian_encoding(device):
 
 
 @pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_gaussian_encoding_no_unfreeze(device):
+    check_cuda(device)
+    b = rff.functional.sample_b(1.0, (256, 2)).to(device)
+    layer = rff.layers.GaussianEncoding(b=b).to(device)
+    layer.requires_grad = True
+    assert layer.b.requires_grad != True
+
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
 def test_gaussian_encoding_register_buffer(device):
     check_cuda(device)
     b = rff.functional.sample_b(1.0, (256, 2)).to(device)


### PR DESCRIPTION
Creating release 1.0.1 to fix issue with register_buffer on 'b' field. I added a test to check to make sure the requires_grad is not changed to true if the layer's requires_grad is set to true.

Also, I added 'ij' to meshgrid call, as it appears torch wants to move to have the same behavior as `np.meshgrid`:
https://github.com/pytorch/pytorch/issues/50276