### PR TITLE
fix: readthedocs did not have build yaml

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,10 +27,15 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: "3"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html


### PR DESCRIPTION
This pull request introduces updates to CI/CD workflows and documentation build configurations. The most important changes include hardening the runner in the dependency review workflow, updating action versions to specific commit hashes, and specifying the operating system and Python version for Read the Docs builds.

### CI/CD Workflow Updates:
* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18R30-R38): Added a step to harden the runner by auditing all outbound calls using `step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863` (v2.12.1). Updated `actions/checkout` and `actions/dependency-review-action` to specific commit hashes for improved traceability (`actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` and `actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9`).

### Documentation Build Configuration:
* [`.readthedocs.yaml`](diffhunk://#diff-03efc769b870804394632e45d7885272b44c16939517fb31c9d7c614d2ffae57R8-R12): Specified `ubuntu-lts-latest` as the operating system and Python version `3` for Read the Docs builds, ensuring compatibility and consistency in the documentation environment.